### PR TITLE
Registration and signing in

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -44,3 +44,4 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_DATABASE_URI = get_database_uri_from_environment()
 SECRET_KEY = environment("SECRET_KEY", default="my_secret_key")
 SENDGRID_API_KEY = environment("SENDGRID_API_KEY", None)
+FRONTEND_BASE_URL = "https://districtr.org"

--- a/api/controllers/__init__.py
+++ b/api/controllers/__init__.py
@@ -10,4 +10,4 @@ def register_blueprints(app):
     app.register_blueprint(users, url_prefix="/users")
     app.register_blueprint(places, url_prefix="/places")
     app.register_blueprint(tokens, url_prefix="/tokens")
-    app.register_blueprint(register_bp, url_prefix="/register")
+    app.register_blueprint(register_bp)

--- a/api/controllers/register.py
+++ b/api/controllers/register.py
@@ -13,10 +13,13 @@ registration_schema = UserSchema(only=("first", "last", "email"))
 
 
 def send_sign_in_email(email, token):
-    link = "https://districtr.org/signin?token={}".format(token)
-    template = current_app.jinja_env.get_template("signin_email.html")
+    base_url = current_app.config["FRONTEND_BASE_URL"]
+    link = base_url + "/signin?token={}".format(token)
+    template = current_app.jinja_env.get_template("verify_email.html")
     content = template.render(link=link)
-    return send_email("sign.in@districtr.org", email, "Sign in to Districtr", content)
+    return send_email(
+        "registration@districtr.org", email, "Confirm your Districtr account", content
+    )
 
 
 @bp.route("/", methods=["POST"])

--- a/api/controllers/register.py
+++ b/api/controllers/register.py
@@ -2,6 +2,8 @@ from flask import Blueprint, current_app, request
 
 from ..auth import create_signin_token
 from ..email import send_email
+from ..exceptions import ApiException
+from ..models import User
 from ..result import ApiResult
 from ..schemas import UserSchema
 from .users import create_user
@@ -10,26 +12,63 @@ bp = Blueprint("register", __name__)
 
 
 registration_schema = UserSchema(only=("first", "last", "email"))
+signin_schema = UserSchema(only=["email"])
 
 
-def send_sign_in_email(email, token):
+def send_signin_email(email, token):
+    base_url = current_app.config["FRONTEND_BASE_URL"]
+    link = base_url + "/signin?token={}".format(token)
+    template = current_app.jinja_env.get_template("signin_email.html")
+    content = template.render(link=link)
+    return send_email("signin@districtr.org", email, "Sign in to Districtr", content)
+
+
+def send_registration_email(email, token):
     base_url = current_app.config["FRONTEND_BASE_URL"]
     link = base_url + "/signin?token={}".format(token)
     template = current_app.jinja_env.get_template("verify_email.html")
     content = template.render(link=link)
     return send_email(
-        "registration@districtr.org", email, "Confirm your Districtr account", content
+        "signup@districtr.org", email, "Confirm your Districtr account", content
     )
 
 
-@bp.route("/", methods=["POST"])
+@bp.route("/register/", methods=["POST"])
 def register():
     """Register a new user."""
     user_data = registration_schema.load(request.get_json())
 
-    user = create_user(user_data)
+    user = User.query.filter_by(email=user_data["email"]).first()
 
-    send_sign_in_email(user.email, token=create_signin_token(user))
+    if user:
+        send_signin_email(user.email, token=create_signin_token(user))
+        return ApiResult(
+            {
+                "message": "This user already exists. A sign-in link has been sent"
+                "to the provided email address."
+            },
+            status=201,
+        )
+
+    user = create_user(user_data)
+    send_registration_email(user.email, token=create_signin_token(user))
+
+    return ApiResult(
+        {"message": "Confirmation link has been sent to the provided email address."},
+        status=201,
+    )
+
+
+@bp.route("/signin/", methods=["POST"])
+def signin():
+    """Sign in via a magic link."""
+    user_data = signin_schema.load(request.get_json())
+
+    user = User.query.filter_by(email=user_data["email"]).first()
+    if not user:
+        raise ApiException("Specified user does not exist.", status=404)
+
+    send_signin_email(user.email, token=create_signin_token(user))
 
     return ApiResult(
         {"message": "Sign-in link has been sent to the provided email address."},

--- a/api/controllers/users.py
+++ b/api/controllers/users.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, jsonify, request
 
 from ..auth import admin_only, authenticate, get_current_user
-from ..exceptions import ApiException
+from ..exceptions import ApiException, Unauthorized
 from ..models import Plan, User, db
 from ..schemas import UserSchema
 from .plans import plans_schema
@@ -44,7 +44,7 @@ def update_user(id):
     user = User.query.get_or_404(id)
 
     if not user.belongs_to(get_current_user()):
-        raise ApiException("You are not authorized to edit this resource.", 403)
+        raise Unauthorized()
 
     data = request.get_json()
     user.update(**data)
@@ -58,8 +58,8 @@ def update_user(id):
 def delete_user(id):
     user = User.query.get_or_404(id)
 
-    if user.id == get_current_user().id:
-        return ApiException("A user cannot delete itself.", 400)
+    if not user.belongs_to(get_current_user()):
+        raise Unauthorized()
 
     db.session.delete(user)
     db.session.commit()

--- a/api/email.py
+++ b/api/email.py
@@ -10,7 +10,7 @@ def send_email(from_address, to_address, subject, body):
         Email(from_address), subject, Email(to_address), Content("text/html", body)
     )
 
-    if current_app.config["TESTING"]:
+    if current_app.config["SEND_EMAILS"] is False:
         print("Sending mail", mail)
         return
 

--- a/api/templates/verify_email.html
+++ b/api/templates/verify_email.html
@@ -29,22 +29,28 @@
                   <h1
                     style="font-size: 40px; font-weight: 300; line-height: 1.2;"
                   >
-                    Sign in to Districtr
+                    Confirm your Districtr account
                   </h1>
                   <h2 style="margin: 36px 0; font-weight: 400; font-size: 24px">
-                    Please click the following link button to sign in to
-                    Districtr.
+                    Please click the following link button to complete your
+                    Districtr registration.
                   </h2>
                   <p style="margin: 36px 0">
                     <a
                       href="{{ link }}"
                       style="text-align: center; font-size: 18px; background: #ff4f49; font-weight: 600; color: white; text-decoration: none; border-radius: 4px; display: block; padding: 8px;"
-                      >Sign in</a
+                      >Confirm registration</a
                     >
                   </p>
-                  <p style="margin: 36px 0; font-size: 18px;">
-                    Clicking on the link will take you back to Districtr.
+                  <p style="margin: 18px 0; font-size: 18px;">
+                    Clicking on the link will sign you in to Districtr, where
+                    you can start drawing your own districting plans.
                   </p>
+                  <p style="margin: 18px 0; font-size: 18px;">
+                    The next time you need to sign in, we'll send you a another
+                    email just like this with a sign-in link.
+                  </p>
+                  <p style="margin: 36px 0; font-size: 18px;"></p>
                   <p style="color: #777;  font-size: 16px;">
                     If the link button does not work, you can copy and paste
                     this URL into your browser's address bar:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,17 +5,19 @@ from api.auth import create_bearer_token
 from api.models import Place, Role, User, db
 from api.schemas import PlanSchema
 
+test_config = {
+    "TESTING": True,
+    "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+    "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+    "SECRET_KEY": b"my_secret_key",
+    "SEND_EMAILS": False,
+    "FRONTEND_BASE_URL": "https://districtr.org",
+}
+
 
 @pytest.fixture
 def app_without_roles(user, plan_record):
-    app = create_app(
-        {
-            "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
-            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
-            "SECRET_KEY": b"my_secret_key",
-        }
-    )
+    app = create_app(test_config)
 
     with app.app_context():
         db.create_all()
@@ -24,14 +26,7 @@ def app_without_roles(user, plan_record):
 
 @pytest.fixture
 def app(user, plan_record):
-    app = create_app(
-        {
-            "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
-            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
-            "SECRET_KEY": b"my_secret_key",
-        }
-    )
+    app = create_app(test_config)
 
     with app.app_context():
         db.create_all()


### PR DESCRIPTION
- Pretty email templates
- Separate `/signin/` and `/register/` routes
- Allow users to delete themselves